### PR TITLE
Feature : Possibility to change the source code folder

### DIFF
--- a/priv/commonjs_reaxt/client_entry_addition.js
+++ b/priv/commonjs_reaxt/client_entry_addition.js
@@ -6,7 +6,8 @@ function default_client_render(props,render,param){
 }
 
 window.reaxt_render = function(module,submodule,props,param){
-  return import(`./../../components/${module}`).then((module)=>{
+  let src_folder = props.src_folder || "components"
+  return import(`./../../${src_folder}/${module}`).then((module)=>{
     module = module.default
     submodule = (submodule) ? module[submodule] :module
     submodule.reaxt_client_render = submodule.reaxt_client_render || default_client_render

--- a/priv/commonjs_reaxt/react_server.js
+++ b/priv/commonjs_reaxt/react_server.js
@@ -57,7 +57,9 @@ Server(function(term,from,state,done){
     done("reply",Bert.tuple(Bert.atom("error"),Bert.tuple(Bert.atom("handler_error"),module,submodule,args,"timeout",Bert.atom("nil"))))
   },timeout)
 
-  import(`./../../components/${module}`).then((handler)=>{
+  let src_folder = args.src_folder || "components"
+
+  import(`./../../${src_folder}/${module}`).then((handler)=>{
     handler = handler.default
     submodule = (submodule == "nil") ? undefined : submodule
     handler = (!submodule) ? handler : handler[submodule]


### PR DESCRIPTION
# Actual Files Organisation and objectif
The actual organisation of the repo is the following
```
web/
  components/
  css/
  node_modules/
  layout.html.eex
  package.json
  webpack.config.js
```
This files and folders organisation merge config files with source folders. My intention is to be able to add a folder level for source code like this
```
web/
  src/
    components/
    css/
    layout.html.eex
  node_modules/
  package.json
  webpack.config.js
```
This way we can more clearly add comlexity in source code organisation with hooks, pages, utils, middleware and all other usefull folders for stronger file organisation.

# The limitations
Today the "components" folder is locked at this place in the folder structure because it is hardcoded. Some workaround are kind of possible but i don't think that having a dependencies forcing a specific folder structure is a good thing.

# The approch
The idea is quit simple, keep the hardcoded "components" folder to not bring breaking changes, but adding an option to change it. The impact on the code should be minimal.

# The Results
## No changes in reaxt-exemple
No errors in the terminal or browser console

## Rename "components" folder to "src"
Obviously we have an error in the terminal
```Bash
** (exit) an exception was raised:
    ** (ReaxtError) JS Handler Exception for %{...}: Error: Cannot find module './components/App'
```
Reaxt use the default configuration and is looking for "components" folder

## Rename + Reaxt config
To add the config, we need to give `Reaxt.render!` the `src_folder` option.
Exemple :
```Elixir
data = %{src_folder: "src", ...}
render = Reaxt.render!(:App, data, 30_000)
```
From here it can works, depends on your previous JS implementation of `reaxt_server_render`.
If the terminal doesn't show any errors but your webpage is broken and browser console say:
```Bash
Uncaught (in promise) Error: Cannot find module './components/App'
```
That means that in the JS part, the component given in the callback function of `reaxt_server_render` doesn't have any props, and the component should have at least the `src_folder` as prop from the first agument.
Exemple:
```JS
reaxt_server_render(params, render) {
  render(<App src_folder={params.src_folder} />)
}
```
After that the implementation should be complete without any errors in the temrinal or browser console.

# Troubleshooting
Please refer to the Result section with the possible bugs explained