### PR TITLE
feat - add missing server to render

### DIFF
--- a/lib/reaxt.ex
+++ b/lib/reaxt.ex
@@ -47,9 +47,9 @@ defmodule Reaxt do
     end
   end
 
-  def render(module,data, timeout \\ 5_000) do
+  def render(module,data, timeout \\ 5_000, chunk \\ :server) do
     try do
-      render!(module,data,timeout)
+      render!(module, data, timeout, chunk)
     rescue
       ex->
         case ex do


### PR DESCRIPTION
Missing the `chunk` parameter when calling `Reaxt.render/3`

This param is present in the `Reaxt.render!/4` with a default value of `:server`

The goal of the PR is to homogenize the function calls. At the moment, you can't call the method for a chunck other than `:server`
It would also help with the handling of potential errors